### PR TITLE
Widdler query updates

### DIFF
--- a/resources/hello_remote.json
+++ b/resources/hello_remote.json
@@ -1,5 +1,6 @@
 {
   "hello.infile": "",
+  "hello.onprem_download_path": "/cil/shed/sandboxes/amr/",
   "hello.fofn": "gs://broad-cil-devel-bucket/input_data/hello_remote.fofn",
   "hello.name": "amr",
   "hello.sleep": 1

--- a/resources/hello_world.wdl
+++ b/resources/hello_world.wdl
@@ -39,7 +39,7 @@ workflow hello {
     File fofn
     String name
     Int sleep
-    Array[File] file_array
+#    Array[File] file_array
     File ? optional_file
 
     String onprem_download_path = "/cil/shed/resources/jenkins_tests/"
@@ -58,14 +58,14 @@ workflow hello {
         }
     }
 
-    call print_contents {
-        input: input_file = fofn, optional_file = optional_file
-    }
-
-    scatter(f in file_array) {
-        call print_contents as pc2 {
-            input: input_file = f
-        }
-    }
+#    call print_contents {
+#        input: input_file = fofn, optional_file = optional_file
+#    }
+#
+#    scatter(f in file_array) {
+#        call print_contents as pc2 {
+#            input: input_file = f
+#        }
+#    }
 
 }

--- a/tests/test_cromwell.py
+++ b/tests/test_cromwell.py
@@ -30,27 +30,6 @@ class CromwellUnitTests(unittest.TestCase):
         self.assertEqual(len(wfid), 36)
         self.cromwell.stop_workflow(wfid)
 
-    def test_query_status(self):
-        wf = self._initiate_workflow()
-        wfid = wf['id']
-        result = self.cromwell.query_status(wfid)
-        self.assertTrue('id' in result and 'status' in result)
-        self.cromwell.stop_workflow(wfid)
-
-    def test_query_metadata(self):
-        wf = self._initiate_workflow()
-        wfid = wf['id']
-        result = self.cromwell.query_metadata(wfid)
-        self.assertTrue('id' in result and 'submission' in result)
-        self.cromwell.stop_workflow(wfid)
-
-    def test_query_logs(self):
-        wf = self._initiate_workflow()
-        wfid = wf['id']
-        result = self.cromwell.query_logs(wfid)
-        self.assertTrue('id' in result)
-        self.cromwell.stop_workflow(wfid)
-
     def test_build_long_url(self):
         wf = self._initiate_workflow()
         wfid = wf['id']
@@ -65,41 +44,12 @@ class CromwellUnitTests(unittest.TestCase):
         self.assertEquals(r.status_code, 200)
         self.cromwell.stop_workflow(wfid)
 
-    def test_query(self):
-        wf = self._initiate_workflow()
-        wfid = wf['id']
-        url_dict = {
-            'name': 'gatk',
-            'id': [wfid],
-            'start': datetime.datetime.now() - datetime.timedelta(days=1),
-            'end': datetime.datetime.now()
-        }
-        result = self.cromwell.query(url_dict)
-        self.assertTrue(isinstance(result['results'], list), True)
-        self.cromwell.stop_workflow(wfid)
-
     def test_label_workflow(self):
         wf = self._initiate_workflow()
         wfid = wf['id']
         r = self.cromwell.label_workflow(wfid, self.labels)
         self.assertEquals(r.status_code, 200)
         self.cromwell.stop_workflow(wfid)
-
-    def test_query_labels(self):
-        wf = self._initiate_workflow()
-        wfid = wf['id']
-        labels = {'username': 'amr', 'foo': 'bar'}
-        self.cromwell.label_workflow(wfid, self.labels)
-        # This sleep is needed to make sure the label workflow completes before we query for it.
-        time.sleep(5)
-        r = self.cromwell.query_labels(labels)
-        # Here, the most recent workflow that matches the query will be the last item so we can use that to check
-        # this assertion.
-        self.assertTrue(wfid in r['results'][-1]['id'])
-        self.cromwell.stop_workflow(wfid)
-
-    def test_query_backend(self):
-        self.assertTrue('defaultBackend' in self.cromwell.query_backend())
 
     def test_explain(self):
         wf = self._initiate_workflow()
@@ -115,7 +65,6 @@ class CromwellUnitTests(unittest.TestCase):
         result = self.cromwell.stop_workflow(wfid)
         print(result)
         self.cromwell.stop_workflow(wfid)
-
 
     @classmethod
     def tearDownClass(self):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -90,15 +90,17 @@ class QueryUnitTests(unittest.TestCase):
         self.assertTrue(wfid in r['results'][-1]['id'])
         self.cromwell.stop_workflow(wfid)
 
-    def test_query_filter_by_status(self):
+    def test_query_filter_by_statuses(self):
         from argparse import Namespace
         from widdler import call_list
         wf = self._initiate_workflow()
         wfid = wf['id']
         result = call_list(Namespace(server="btl-cromwell", all=False, no_notify=True, verbose=True, interval=None,
-                                     username="*", days=1, filter=['Succeeded']))
+                                     username="*", days=1, filter=['Succeeded', 'Failed']))
         statuses = set(d['status'] for d in result)
-        self.assertEqual(len(statuses), 1)
+        self.assertEqual(len(statuses), 2)
+        self.assertIn('Succeeded', statuses)
+        self.assertIn('Failed', statuses)
         self.cromwell.stop_workflow(wfid)
 
     def test_query_filter_by_name(self):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,99 @@
+__author__ = 'Amr Abouelleil'
+import unittest
+import os
+import time
+from src.Cromwell import Cromwell
+import src.config as c
+import datetime
+import requests
+
+
+class QueryUnitTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        resources = c.resource_dir
+        self.cromwell = Cromwell(host='btl-cromwell')
+        self.json = os.path.join(resources, 'hello.json')
+        self.wdl = os.path.join(resources, 'hello_world.wdl')
+        self.labels = {'username': 'amr', 'foo': 'bar'}
+
+    def _initiate_workflow(self):
+        wf = self.cromwell.jstart_workflow(self.wdl, self.json)
+        time.sleep(5)
+        return wf
+
+    def test_query_status(self):
+        wf = self._initiate_workflow()
+        wfid = wf['id']
+        result = self.cromwell.query_status(wfid)
+        self.assertTrue('id' in result and 'status' in result)
+        self.cromwell.stop_workflow(wfid)
+
+    def test_query_metadata(self):
+        wf = self._initiate_workflow()
+        wfid = wf['id']
+        result = self.cromwell.query_metadata(wfid)
+        self.assertTrue('id' in result and 'submission' in result)
+        self.cromwell.stop_workflow(wfid)
+
+    def test_query_logs(self):
+        wf = self._initiate_workflow()
+        wfid = wf['id']
+        result = self.cromwell.query_logs(wfid)
+        self.assertTrue('id' in result)
+        self.cromwell.stop_workflow(wfid)
+
+    def test_build_long_url(self):
+        wf = self._initiate_workflow()
+        wfid = wf['id']
+        url_dict = {
+            'name': 'test_build_long_url',
+            'id': wfid,
+            'start': datetime.datetime.now() - datetime.timedelta(days=1),
+            'end': datetime.datetime.now()
+        }
+        query_url = self.cromwell.build_query_url('http://btl-cromwell:9000/api/workflows/v1/query?', url_dict)
+        r = requests.get(query_url)
+        self.assertEquals(r.status_code, 200)
+        self.cromwell.stop_workflow(wfid)
+
+    def test_query(self):
+        wf = self._initiate_workflow()
+        wfid = wf['id']
+        url_dict = {
+            'name': 'gatk',
+            'id': [wfid],
+            'start': datetime.datetime.now() - datetime.timedelta(days=1),
+            'end': datetime.datetime.now()
+        }
+        result = self.cromwell.query(url_dict)
+        self.assertTrue(isinstance(result['results'], list), True)
+        self.cromwell.stop_workflow(wfid)
+
+    def test_label_workflow(self):
+        wf = self._initiate_workflow()
+        wfid = wf['id']
+        r = self.cromwell.label_workflow(wfid, self.labels)
+        self.assertEquals(r.status_code, 200)
+        self.cromwell.stop_workflow(wfid)
+
+    def test_query_labels(self):
+        wf = self._initiate_workflow()
+        wfid = wf['id']
+        labels = {'username': 'amr', 'foo': 'bar'}
+        self.cromwell.label_workflow(wfid, self.labels)
+        # This sleep is needed to make sure the label workflow completes before we query for it.
+        time.sleep(5)
+        r = self.cromwell.query_labels(labels)
+        # Here, the most recent workflow that matches the query will be the last item so we can use that to check
+        # this assertion.
+        self.assertTrue(wfid in r['results'][-1]['id'])
+        self.cromwell.stop_workflow(wfid)
+
+    def test_query_backend(self):
+        self.assertTrue('defaultBackend' in self.cromwell.query_backend())
+
+
+    @classmethod
+    def tearDownClass(self):
+        print("Done!")

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -118,7 +118,6 @@ class QueryUnitTests(unittest.TestCase):
         result = call_list(Namespace(server="btl-cromwell", all=False, no_notify=True, verbose=True, interval=None,
                                      username="*", days=1, filter=None))
         all_dates = set(d['start'].split('T')[0] for d in result)
-        print all_dates
         self.assertEqual(len(all_dates), 1)
 
     def test_query_backend(self):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -90,6 +90,10 @@ class QueryUnitTests(unittest.TestCase):
         self.assertTrue(wfid in r['results'][-1]['id'])
         self.cromwell.stop_workflow(wfid)
 
+    def test_query_user(self):
+        pass
+
+
     def test_query_backend(self):
         self.assertTrue('defaultBackend' in self.cromwell.query_backend())
 

--- a/widdler.py
+++ b/widdler.py
@@ -491,7 +491,7 @@ query.add_argument('workflow_id', nargs='?', default="None", help='workflow id f
 query.add_argument('-s', '--status', action='store_true', default=False, help='Print status for workflow to stdout')
 query.add_argument('-m', '--metadata', action='store_true', default=False, help='Print metadata for workflow to stdout')
 query.add_argument('-l', '--logs', action='store_true', default=False, help='Print logs for workflow to stdout')
-query.add_argument('-u', '--username', action='store', default=getpass.getuser(), help='Owner of workflows to monitor.')
+query.add_argument('-u', '--username', action='store', default=getpass.getuser(), help='Owner of workflows to query.')
 query.add_argument('-L', '--label', action='append', help='Query status of all workflows with specific label(s).')
 query.add_argument('-d', '--days', action='store', default=7, help='Last n days to query.')
 query.add_argument('-S', '--server', action='store', required=True, type=str, choices=c.servers,

--- a/widdler.py
+++ b/widdler.py
@@ -315,7 +315,7 @@ def call_list(args):
         printer.format = my_safe_repr
         printer.pprint(result)
         args.monitor = True
-        return None
+        return result
     except KeyError as e:
         logger.critical('KeyError: Unable to find key {}'.format(e))
 
@@ -374,7 +374,7 @@ def call_log(args):
         command = command + key + ":\n\n"
         command = command + command_log + "\n\n"
 
-    print(command) #print to stdout
+    print(command)  # print to stdout
     return None
 
 
@@ -585,10 +585,8 @@ upload.add_argument('-d', '--dependencies', action='store', default=None, type=i
 upload.set_defaults(func=call_upload)
 
 
-args = parser.parse_args()
-
-
 def main():
+    args = parser.parse_args()
     # Get user's username so we can tag workflows and logs for them.
     user = getpass.getuser()
     try:

--- a/widdler.py
+++ b/widdler.py
@@ -308,6 +308,8 @@ def call_list(args):
     q = m.get_user_workflows(raw=True, start_time=start_date_str)
     try:
         result = q["results"]
+        if args.filter:
+            result = [res for res in result if res['status'] in args.filter]
         result = map(lambda j: process_job(j), result)
         printer = pprint.PrettyPrinter()
         printer.format = my_safe_repr


### PR DESCRIPTION
Changes made on this pull request:
-applied filtering logic in widdler.py call_list function for filtering query results by status.
-moved parse_args() call to main function of widdler.py to resolve issue where calls to functions in widdler.py from unit tests would fail.
-added test_query_filter_by_status, test_query_filter_by_name, test_query_filter_by_days unit tests.
-moved query-related tests from test_cromwell.py to new file, test_query.py.
-removed print statement used for discovery from test_queries.py